### PR TITLE
hash40("{}") only for known labels

### DIFF
--- a/hash40.py
+++ b/hash40.py
@@ -25,7 +25,7 @@ class Hash40:
         find = next((x for x in HashLabels if x.hash40 == self.hash40), None)
         if find:
             if find.label != '':
-                return find.label
+                return 'hash40("{0}")'.format(find.label)
         return self.hash40
 
     @staticmethod

--- a/scriptparser.py
+++ b/scriptparser.py
@@ -149,7 +149,7 @@ class Value:
                     functionName = functionName.split('.')[2]
                 return '{0}'.format(functionName)
         elif self.type == 'hash40':
-            return 'hash40("{0}")'.format(self.value.getLabel())
+            return self.value.getLabel()
         elif self.type == 'int':
             return int(self.value)
         else:


### PR DESCRIPTION
Ideally, we should have `hash40("")` wrapping only for known labels as strings. Otherwise we can have just the u64 value. Currently, we have situations like:
`notify_event_msc_cmd(hash40("0x2127e37c07"), GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES)`

which should be:
`notify_event_msc_cmd(0x2127e37c07, GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES)`